### PR TITLE
Rename on_/off_ event APIs to register_/unregister_…_handler naming

### DIFF
--- a/src/chrme_dom.erl
+++ b/src/chrme_dom.erl
@@ -1,6 +1,6 @@
 -module(chrme_dom).
 -export([get_document/1, query_selector/3, get_outer_html/2, set_attribute_value/4,
-         remove_node/2, on_document_updated/2, off_document_updated/2]).
+         remove_node/2, register_document_updated_handler/2, unregister_document_updated_handler/2]).
 
 %% Get the root document node
 -spec get_document(Name :: chrme_session:name()) -> {ok, map()} | {error, term()}.
@@ -45,10 +45,10 @@ remove_node(Name, NodeId) ->
     chrme_cdp:call(Name, <<"DOM.removeNode">>, #{nodeId => NodeId}).
 
 %% Subscribe to documentUpdated events
--spec on_document_updated(Name :: chrme_session:name(), Fun :: fun(() -> any())) -> reference().
-on_document_updated(Name, Fun) ->
+-spec register_document_updated_handler(Name :: chrme_session:name(), Fun :: fun(() -> any())) -> reference().
+register_document_updated_handler(Name, Fun) ->
     Ref = make_ref(),
-    CallbackName = {chrme_dom, on_document_updated, Name, Ref},
+    CallbackName = {chrme_dom, register_document_updated_handler, Name, Ref},
     CallbackFun = fun
         (stop) -> false;
         (Msg = #{<<"method">> := <<"DOM.documentUpdated">>, <<"params">> := Params}) ->
@@ -59,8 +59,8 @@ on_document_updated(Name, Fun) ->
     chrme_ws_apic:add_callback(Name, {CallbackName, CallbackFun}),
     Ref.
 
--spec off_document_updated(Name :: chrme_session:name(), Ref :: reference()) -> ok.
-off_document_updated(Name, Ref) ->
-    CallbackName = {chrme_dom, on_document_updated, Name, Ref},
+-spec unregister_document_updated_handler(Name :: chrme_session:name(), Ref :: reference()) -> ok.
+unregister_document_updated_handler(Name, Ref) ->
+    CallbackName = {chrme_dom, register_document_updated_handler, Name, Ref},
     chrme_ws_apic:remove_callback(Name, CallbackName),
     ok.

--- a/src/chrme_network.erl
+++ b/src/chrme_network.erl
@@ -1,7 +1,7 @@
 -module(chrme_network).
 -export([enable/1, disable/1, set_request_interception/2,
          continue_intercepted_request/2, emulate_network_conditions/2,
-         on_request_will_be_sent/2, off_request_will_be_sent/2]).
+         register_request_will_be_sent_handler/2, unregister_request_will_be_sent_handler/2]).
 
 %% Enable network tracking
 -spec enable(Name :: chrme_session:name()) -> {ok, map()} | {error, term()}.
@@ -29,10 +29,10 @@ emulate_network_conditions(Name, Conditions) ->
     chrme_cdp:call(Name, <<"Network.emulateNetworkConditions">>, Conditions).
 
 %% Subscribe to requestWillBeSent events
--spec on_request_will_be_sent(Name :: chrme_session:name(), Fun :: fun((map()) -> any())) -> reference().
-on_request_will_be_sent(Name, Fun) ->
+-spec register_request_will_be_sent_handler(Name :: chrme_session:name(), Fun :: fun((map()) -> any())) -> reference().
+register_request_will_be_sent_handler(Name, Fun) ->
     Ref = make_ref(),
-    CallbackName = {chrme_network, on_request_will_be_sent, Name, Ref},
+    CallbackName = {chrme_network, register_request_will_be_sent_handler, Name, Ref},
     CallbackFun = fun
         (stop) -> false;
         (Msg = #{<<"method">> := <<"Network.requestWillBeSent">>, <<"params">> := Params}) ->
@@ -44,8 +44,8 @@ on_request_will_be_sent(Name, Fun) ->
     Ref.
 
 %% Unsubscribe from requestWillBeSent
--spec off_request_will_be_sent(Name :: chrme_session:name(), Ref :: reference()) -> ok.
-off_request_will_be_sent(Name, Ref) ->
-    CallbackName = {chrme_network, on_request_will_be_sent, Name, Ref},
+-spec unregister_request_will_be_sent_handler(Name :: chrme_session:name(), Ref :: reference()) -> ok.
+unregister_request_will_be_sent_handler(Name, Ref) ->
+    CallbackName = {chrme_network, register_request_will_be_sent_handler, Name, Ref},
     chrme_ws_apic:remove_callback(Name, CallbackName),
     ok.

--- a/src/chrme_page.erl
+++ b/src/chrme_page.erl
@@ -1,6 +1,6 @@
 -module(chrme_page).
 -export([enable/1, navigate/2, reload/1, stop_loading/1, capture_screenshot/1,
-         on_frame_navigated/2, off_frame_navigated/2]).
+         register_frame_navigated_handler/2, unregister_frame_navigated_handler/2]).
 
 -export_type([navigation/0]).
 -type navigation() :: #{
@@ -57,10 +57,10 @@ capture_screenshot(Name) ->
     end.
 
 %% Subscribe to frameNavigated events
--spec on_frame_navigated(Name :: chrme_session:name(), Fun :: fun((map()) -> any())) -> reference().
-on_frame_navigated(Name, Fun) ->
+-spec register_frame_navigated_handler(Name :: chrme_session:name(), Fun :: fun((map()) -> any())) -> reference().
+register_frame_navigated_handler(Name, Fun) ->
     Ref = make_ref(),
-    CallbackName = {chrme_page, on_frame_navigated, Name, Ref},
+    CallbackName = {chrme_page, register_frame_navigated_handler, Name, Ref},
     CallbackFun = fun
         (stop) ->
             false;
@@ -73,8 +73,8 @@ on_frame_navigated(Name, Fun) ->
     chrme_ws_apic:add_callback(Name, {CallbackName, CallbackFun}),
     Ref.
 
--spec off_frame_navigated(Name :: chrme_session:name(), Ref :: reference()) -> ok.
-off_frame_navigated(Name, Ref) ->
-    CallbackName = {chrme_page, on_frame_navigated, Name, Ref},
+-spec unregister_frame_navigated_handler(Name :: chrme_session:name(), Ref :: reference()) -> ok.
+unregister_frame_navigated_handler(Name, Ref) ->
+    CallbackName = {chrme_page, register_frame_navigated_handler, Name, Ref},
     chrme_ws_apic:remove_callback(Name, CallbackName),
     ok.

--- a/src/chrme_runtime.erl
+++ b/src/chrme_runtime.erl
@@ -1,6 +1,6 @@
 -module(chrme_runtime).
 -export([evaluate/2, call_function_on/4, add_binding/2, remove_binding/2,
-         on_exception_thrown/2, off_exception_thrown/2]).
+         register_exception_thrown_handler/2, unregister_exception_thrown_handler/2]).
 
 %% Evaluate a JavaScript expression in the page
 evaluate(Name, Expr0) ->
@@ -36,9 +36,9 @@ remove_binding(Name, BindingName0) ->
     chrme_cdp:call(Name, <<"Runtime.removeBinding">>, #{name => NameBin}).
 
 %% Subscribe to exceptionThrown events
-on_exception_thrown(Name, Fun) ->
+register_exception_thrown_handler(Name, Fun) ->
     Ref = make_ref(),
-    CallbackName = {chrme_runtime, on_exception_thrown, Name, Ref},
+    CallbackName = {chrme_runtime, register_exception_thrown_handler, Name, Ref},
     CallbackFun = fun
         (stop) -> false;
         (Msg = #{<<"method">> := <<"Runtime.exceptionThrown">>, <<"params">> := Params}) ->
@@ -49,7 +49,7 @@ on_exception_thrown(Name, Fun) ->
     chrme_ws_apic:add_callback(Name, {CallbackName, CallbackFun}),
     Ref.
 
-off_exception_thrown(Name, Ref) ->
-    CallbackName = {chrme_runtime, on_exception_thrown, Name, Ref},
+unregister_exception_thrown_handler(Name, Ref) ->
+    CallbackName = {chrme_runtime, register_exception_thrown_handler, Name, Ref},
     chrme_ws_apic:remove_callback(Name, CallbackName),
     ok.

--- a/src/chrme_runtime.erl
+++ b/src/chrme_runtime.erl
@@ -36,6 +36,7 @@ remove_binding(Name, BindingName0) ->
     chrme_cdp:call(Name, <<"Runtime.removeBinding">>, #{name => NameBin}).
 
 %% Subscribe to exceptionThrown events
+-spec register_exception_thrown_handler(Name :: chrme_session:name(), Fun :: fun((map()) -> any())) -> reference().
 register_exception_thrown_handler(Name, Fun) ->
     Ref = make_ref(),
     CallbackName = {chrme_runtime, register_exception_thrown_handler, Name, Ref},
@@ -49,6 +50,8 @@ register_exception_thrown_handler(Name, Fun) ->
     chrme_ws_apic:add_callback(Name, {CallbackName, CallbackFun}),
     Ref.
 
+%% Unsubscribe from exceptionThrown events
+-spec unregister_exception_thrown_handler(Name :: chrme_session:name(), Ref :: reference()) -> ok.
 unregister_exception_thrown_handler(Name, Ref) ->
     CallbackName = {chrme_runtime, register_exception_thrown_handler, Name, Ref},
     chrme_ws_apic:remove_callback(Name, CallbackName),

--- a/test/chrme_session_SUITE.erl
+++ b/test/chrme_session_SUITE.erl
@@ -84,7 +84,7 @@ simple(_Config) ->
         %%    assert that we observe the request via the
         %%    Network.requestWillBeSent event.
         Self = self(),
-        RefNetwork = chrme_network:on_request_will_be_sent(session1, fun(Params) ->
+        RefNetwork = chrme_network:register_request_will_be_sent_handler(session1, fun(Params) ->
             Req = maps:get(<<"request">>, Params, #{}),
             case maps:get(<<"url">>, Req, <<>> ) of
                 <<"https://example.com/">> ->
@@ -105,13 +105,13 @@ simple(_Config) ->
             ct:fail(network_event_timeout)
         end,
 
-        chrme_network:off_request_will_be_sent(session1, RefNetwork),
+        chrme_network:unregister_request_will_be_sent_handler(session1, RefNetwork),
 
         %% 8. Navigate to https://example.org and wait for the navigation
         %%    to complete (signalled by Page.frameNavigated).
         {ok, _} = chrme_page:enable(session1),
 
-        RefNav = chrme_page:on_frame_navigated(session1, fun(_Params) ->
+        RefNav = chrme_page:register_frame_navigated_handler(session1, fun(_Params) ->
             Self ! frame_nav,
             true
         end),
@@ -124,7 +124,7 @@ simple(_Config) ->
             ct:fail(navigation_timeout)
         end,
 
-        chrme_page:off_frame_navigated(session1, RefNav),
+        chrme_page:unregister_frame_navigated_handler(session1, RefNav),
 
         %% 9. Clean shutdown.
         ok = chrme_session:stop(Session),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated event handler registration and unregistration function names across multiple modules for improved clarity. Existing "on_" and "off_" function names have been replaced with "register_" and "unregister_" prefixes.
- **Tests**
  - Modified test code to use the new event handler function names. No changes to test logic or coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->