### PR TITLE
feat(network): add generic Network.* event handler API and tests

### DIFF
--- a/src/chrme_network.erl
+++ b/src/chrme_network.erl
@@ -1,7 +1,8 @@
 -module(chrme_network).
 -export([enable/1, disable/1, set_request_interception/2,
          continue_intercepted_request/2, emulate_network_conditions/2,
-         register_request_will_be_sent_handler/2, unregister_request_will_be_sent_handler/2]).
+         register_request_will_be_sent_handler/2, unregister_request_will_be_sent_handler/2,
+         register_event_handler/2, unregister_event_handler/2]).
 
 %% Enable network tracking
 -spec enable(Name :: chrme_session:name()) -> {ok, map()} | {error, term()}.
@@ -35,7 +36,7 @@ register_request_will_be_sent_handler(Name, Fun) ->
     CallbackName = {chrme_network, register_request_will_be_sent_handler, Name, Ref},
     CallbackFun = fun
         (stop) -> false;
-        (Msg = #{<<"method">> := <<"Network.requestWillBeSent">>, <<"params">> := Params}) ->
+        (_Msg = #{<<"method">> := <<"Network.requestWillBeSent">>, <<"params">> := Params}) ->
             Fun(Params),
             true;
         (_) -> false
@@ -47,5 +48,39 @@ register_request_will_be_sent_handler(Name, Fun) ->
 -spec unregister_request_will_be_sent_handler(Name :: chrme_session:name(), Ref :: reference()) -> ok.
 unregister_request_will_be_sent_handler(Name, Ref) ->
     CallbackName = {chrme_network, register_request_will_be_sent_handler, Name, Ref},
+    chrme_ws_apic:remove_callback(Name, CallbackName),
+    ok.
+
+%% ------------------------------------------------------------------
+%%  New convenience: listen to *all* Network domain events.
+%% ------------------------------------------------------------------
+
+%% Subscribe to every "Network.*" event.
+-spec register_event_handler(Name :: chrme_session:name(),
+                             Fun  :: fun((map()) -> any())) -> reference().
+register_event_handler(Name, Fun) ->
+    Ref = make_ref(),
+    CallbackName = {chrme_network, register_event_handler, Name, Ref},
+    CallbackFun = fun
+        (stop) ->
+            false;
+        (Msg = #{<<"method">> := Method}) ->
+            case Method of
+                <<"Network.", _/binary>> ->
+                    Fun(Msg),
+                    true;
+                _ ->
+                    false
+            end;
+        (_) ->
+            false
+    end,
+    chrme_ws_apic:add_callback(Name, {CallbackName, CallbackFun}),
+    Ref.
+
+%% Unsubscribe from all Network.* events.
+-spec unregister_event_handler(Name :: chrme_session:name(), Ref :: reference()) -> ok.
+unregister_event_handler(Name, Ref) ->
+    CallbackName = {chrme_network, register_event_handler, Name, Ref},
     chrme_ws_apic:remove_callback(Name, CallbackName),
     ok.

--- a/test/chrme_session_SUITE.erl
+++ b/test/chrme_session_SUITE.erl
@@ -3,12 +3,12 @@
 
 %% Exported callbacks --------------------------------------------------------
 
--export([all/0, simple/1]).
+-export([all/0, simple/1, network_events/1]).
 
 %% Test case list ------------------------------------------------------------
 
 all() ->
-    [simple].
+    [simple, network_events].
 
 %%---------------------------------------------------------------------------
 %% Test cases
@@ -131,4 +131,72 @@ simple(_Config) ->
         ok
     after
         chrme_launcher:stop(launch1)
+    end.
+
+%%---------------------------------------------------------------------------
+%% Test case: network_events
+%%---------------------------------------------------------------------------
+
+network_events(_Config) ->
+    application:ensure_all_started(chrme),
+
+    %% Pick a free debugging port for Chrome.
+    {ok, LSock} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = inet:sockname(LSock),
+    ok = gen_tcp:close(LSock),
+
+    UserDataDir = list_to_binary(io_lib:format("/tmp/chrme_ud_ne_~p", [Port])),
+
+    LauncherOpts = #{ name          => launch_ne,
+                      remote_port   => Port,
+                      user_data_dir => UserDataDir,
+                      headless      => true,
+                      extra_args    => [ <<"--remote-allow-origins=*">> ]
+                    },
+    {ok, _PidLaunch} = chrme_launcher:start_link(LauncherOpts),
+    ok = chrme_launcher:await_start(launch_ne),
+
+    try
+        {ok, Session} = chrme_session:start_link(session_ne,
+                                           <<"localhost">>,
+                                           Port,
+                                           <<"https://example.com">>),
+        ok = chrme_session:await_start(session_ne),
+
+        Self = self(),
+
+        RefNet = chrme_network:register_event_handler(session_ne, fun(Event) ->
+            Method = maps:get(<<"method">>, Event, undefined),
+            case Method of
+                <<"Network.requestWillBeSent">> ->
+                    Self ! will;
+                <<"Network.responseReceived">> ->
+                    Self ! resp;
+                _ -> ok
+            end,
+            true
+        end),
+
+        {ok, _} = chrme_network:enable(session_ne),
+
+        %% Trigger a fetch inside the page.
+        _ = chrme_runtime:evaluate(session_ne, <<"fetch('https://example.com/')">>),
+
+        %% Wait for both requestWillBeSent and responseReceived to ensure multiple events.
+        receive
+            will -> ok
+        after 5000 -> ct:fail(missing_request_will_be_sent)
+        end,
+
+        receive
+            resp -> ok
+        after 5000 -> ct:fail(missing_response_received)
+        end,
+
+        chrme_network:unregister_event_handler(session_ne, RefNet),
+
+        ok = chrme_session:stop(Session),
+        ok
+    after
+        chrme_launcher:stop(launch_ne)
     end.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to register and unregister generic event handlers for all Chrome DevTools Protocol Network domain events.

- **Tests**
  - Introduced a new test case to verify capturing multiple network events using a generic event handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->