### PR TITLE
network: add await_response_body helper and tests

### DIFF
--- a/src/chrme_network.erl
+++ b/src/chrme_network.erl
@@ -1,11 +1,15 @@
 -module(chrme_network).
+
+-export_type([request_id/0]).
+
+-type request_id() :: klsn:binstr().
 -export([enable/1, disable/1, set_request_interception/2,
          continue_intercepted_request/2, emulate_network_conditions/2,
          register_request_will_be_sent_handler/2, unregister_request_will_be_sent_handler/2,
          register_event_handler/2, unregister_event_handler/2,
          register_response_received_handler/2, unregister_response_received_handler/2,
          register_loading_finished_handler/2, unregister_loading_finished_handler/2,
-         get_response_body/2]).
+         get_response_body/2, await_response_body/3, await_response_body/2]).
 
 %% Enable network tracking
 -spec enable(Name :: chrme_session:name()) -> {ok, map()} | {error, term()}.
@@ -23,7 +27,7 @@ set_request_interception(Name, Patterns) ->
     chrme_cdp:call(Name, <<"Network.setRequestInterception">>, #{patterns => Patterns}).
 
 %% Continue an intercepted request
--spec continue_intercepted_request(Name :: chrme_session:name(), RequestId :: klsn:binstr()) -> {ok, map()} | {error, term()}.
+-spec continue_intercepted_request(Name :: chrme_session:name(), RequestId :: request_id()) -> {ok, map()} | {error, term()}.
 continue_intercepted_request(Name, RequestId) ->
     chrme_cdp:call(Name, <<"Network.continueInterceptedRequest">>, #{requestId => RequestId}).
 
@@ -55,6 +59,35 @@ unregister_request_will_be_sent_handler(Name, Ref) ->
     ok.
 
 %% ------------------------------------------------------------------
+%%  Await response body helper
+%% ------------------------------------------------------------------
+
+-spec await_response_body(chrme_session:name(), request_id(), non_neg_integer()) ->
+          {ok, binary(), boolean()} | {error, timeout | term()}.
+await_response_body(Name, ReqId, Timeout) when is_integer(Timeout), Timeout >= 0 ->
+    Start = erlang:monotonic_time(millisecond),
+    Poll = fun This() ->
+        case get_response_body(Name, ReqId) of
+            {ok, _Body, _Enc} = Success ->
+                Success;
+            _ ->
+                Now = erlang:monotonic_time(millisecond),
+                case Now - Start >= Timeout of
+                    true -> {error, timeout};
+                    false ->
+                        timer:sleep(100),
+                        This()
+                end
+        end
+    end,
+    Poll().
+
+-spec await_response_body(chrme_session:name(), request_id()) ->
+          {ok, binary(), boolean()} | {error, timeout | term()}.
+await_response_body(Name, ReqId) ->
+    await_response_body(Name, ReqId, 5000).
+
+%% ------------------------------------------------------------------
 %%  Convenience: fetch response body for a completed request.
 %%  Wraps the CDP method Network.getResponseBody
 %% ------------------------------------------------------------------
@@ -64,7 +97,7 @@ unregister_request_will_be_sent_handler(Name, Ref) ->
 %% can decide whether to decode.
 
 -spec get_response_body(Name :: chrme_session:name(),
-                       RequestId :: klsn:binstr()) ->
+                       RequestId :: request_id()) ->
           {ok, binary(), boolean()} | {error, term()}.
 get_response_body(Name, RequestId) ->
     case chrme_cdp:call(Name, <<"Network.getResponseBody">>, #{requestId => RequestId}) of

--- a/src/chrme_network.erl
+++ b/src/chrme_network.erl
@@ -62,8 +62,18 @@ unregister_request_will_be_sent_handler(Name, Ref) ->
 %%  Await response body helper
 %% ------------------------------------------------------------------
 
--spec await_response_body(chrme_session:name(), request_id(), non_neg_integer()) ->
+-spec await_response_body(chrme_session:name(), request_id(), infinity | non_neg_integer()) ->
           {ok, binary(), boolean()} | {error, timeout | term()}.
+await_response_body(Name, ReqId, infinity) ->
+    %% Infinite wait: keep polling until success.
+    case get_response_body(Name, ReqId) of
+        {ok, _Body, _Enc} = Success ->
+            Success;
+        _ ->
+            timer:sleep(100),
+            await_response_body(Name, ReqId, infinity)
+    end;
+
 await_response_body(Name, ReqId, Timeout) when is_integer(Timeout), Timeout >= 0 ->
     Start = erlang:monotonic_time(millisecond),
     Poll = fun This() ->
@@ -85,7 +95,7 @@ await_response_body(Name, ReqId, Timeout) when is_integer(Timeout), Timeout >= 0
 -spec await_response_body(chrme_session:name(), request_id()) ->
           {ok, binary(), boolean()} | {error, timeout | term()}.
 await_response_body(Name, ReqId) ->
-    await_response_body(Name, ReqId, 5000).
+    await_response_body(Name, ReqId, infinity).
 
 %% ------------------------------------------------------------------
 %%  Convenience: fetch response body for a completed request.

--- a/test/chrme_session_SUITE.erl
+++ b/test/chrme_session_SUITE.erl
@@ -3,12 +3,12 @@
 
 %% Exported callbacks --------------------------------------------------------
 
--export([all/0, simple/1, network_events/1, event_handler/1]).
+-export([all/0, simple/1, network_events/1, event_handler/1, response_body/1]).
 
 %% Test case list ------------------------------------------------------------
 
 all() ->
-    [simple, network_events, event_handler].
+    [simple, network_events, event_handler, response_body].
 
 %%---------------------------------------------------------------------------
 %% Test cases
@@ -131,6 +131,70 @@ simple(_Config) ->
         ok
     after
         chrme_launcher:stop(launch1)
+    end.
+
+%%---------------------------------------------------------------------------
+%% Test case: response_body (await_response_body helper)
+%%---------------------------------------------------------------------------
+
+response_body(_Config) ->
+    application:ensure_all_started(chrme),
+
+    %% Allocate free port
+    {ok, LSock} = gen_tcp:listen(0, [binary,{active,false}]),
+    {ok, {_, Port}} = inet:sockname(LSock),
+    ok = gen_tcp:close(LSock),
+
+    UserDataDir = list_to_binary(io_lib:format("/tmp/chrme_ud_rb_~p", [Port])),
+
+    LauncherOpts = #{ name => launch_rb,
+                      remote_port => Port,
+                      user_data_dir => UserDataDir,
+                      headless => true,
+                      extra_args => [ <<"--remote-allow-origins=*">> ] },
+
+    {ok, _} = chrme_launcher:start_link(LauncherOpts),
+    ok = chrme_launcher:await_start(launch_rb),
+
+    try
+        {ok, SessionMap} = chrme_session:start_link(session_rb,
+                                            <<"localhost">>,
+                                            Port,
+                                            <<"https://example.com">>),
+        ok = chrme_session:await_start(session_rb),
+
+        Self = self(),
+
+        %% Capture requestId via responseReceived event
+        RefResp = chrme_network:register_response_received_handler(session_rb, fun(Params) ->
+            RespInfo = maps:get(<<"response">>, Params, #{}),
+            case maps:get(<<"url">>, RespInfo, <<>> ) of
+                <<"https://example.com/">> ->
+                    ReqId = maps:get(<<"requestId">>, Params, undefined),
+                    Self ! {rid, ReqId},
+                    true;
+                _ -> false
+            end
+        end),
+
+        {ok, _} = chrme_network:enable(session_rb),
+
+        _ = chrme_runtime:evaluate(session_rb, <<"fetch('https://example.com/')">>),
+
+        ReqId = receive
+            {rid, R} -> R
+        after 5000 -> ct:fail(missing_request_id)
+        end,
+
+        {ok, Body, _Encoded} = chrme_network:await_response_body(session_rb, ReqId, 5000),
+        true = byte_size(Body) > 0,
+
+        chrme_network:unregister_response_received_handler(session_rb, RefResp),
+
+        ok = chrme_session:stop(SessionMap),
+        ok
+    after
+        chrme_launcher:stop(launch_rb)
     end.
 
 %%---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a function to wait for and retrieve HTTP response bodies with a configurable timeout.

- **Tests**
  - Introduced a new test to verify that HTTP response bodies can be successfully retrieved and are non-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->